### PR TITLE
通过正则严格匹配并忽略`Reconnecting... X/Y`类型的重连尝试警告

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "codexmcp"
-version = "0.1.0"
+version = "0.7.4"
 description = "FastMCP server wrapping the Codex CLI."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/codexmcp/server.py
+++ b/src/codexmcp/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import queue
+import re
 import subprocess
 import threading
 import uuid
@@ -219,8 +220,11 @@ async def codex(
                 success = False if len(agent_messages) == 0 else success
                 err_message = "codex error: " + line_dict.get("error", {}).get("message", "")
             if "error" in line_dict.get("type", ""):
-                success = False if len(agent_messages) == 0 else success
-                err_message = "codex error: " + line_dict.get("message", "")   
+                error_msg = line_dict.get("message", "")
+                is_reconnecting = bool(re.match(r'^Reconnecting\.\.\.\s+\d+/\d+$', error_msg))
+                if not is_reconnecting:
+                    success = False if len(agent_messages) == 0 else success
+                    err_message = "codex error: " + error_msg
         except json.JSONDecodeError as error:
             # Improved error handling: include problematic line
             err_message = line

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ wheels = [
 
 [[package]]
 name = "codexmcp"
-version = "0.1.0"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
修改 https://github.com/GuDaStudio/codexmcp/issues/7 和 https://github.com/GuDaStudio/codexmcp/issues/22 中提到的由于网络波动导致重连会使得MCP直接判断为失败的问题

测试如下，左侧为当前0.7.3版本，右侧为PR版本，通过手动断网来虚拟重连的场景

<img width="3097" height="1476" alt="图片" src="https://github.com/user-attachments/assets/62711b1d-4a2f-4e01-8a98-c7a058755bef" />
