### PR TITLE
fix: improve reconnecting regex to match messages with error details

### DIFF
--- a/src/codexmcp/server.py
+++ b/src/codexmcp/server.py
@@ -240,8 +240,8 @@ async def codex(
                 err_message += "\n\n[codex error] " + line_dict.get("error", {}).get("message", "")
             if "error" in line_dict.get("type", ""):
                 error_msg = line_dict.get("message", "")
-                import re 
-                is_reconnecting = bool(re.match(r'^Reconnecting\.\.\.\s+\d+/\d+$', error_msg))
+                import re
+                is_reconnecting = bool(re.match(r'^Reconnecting\.\.\.\s+\d+/\d+', error_msg))
                 
                 if not is_reconnecting:
                     success = False if len(agent_messages) == 0 else success


### PR DESCRIPTION
## Summary

- Remove the trailing `$` anchor from the reconnecting regex pattern
- This allows matching messages like `"Reconnecting... 1/5 (stream disconnected...)"` instead of only `"Reconnecting... 1/5"`

## Problem

The current regex pattern:
```python
r'^Reconnecting\.\.\.\s+\d+/\d+$'
```

Only matches exact strings like `"Reconnecting... 1/5"`, but fails to match messages with additional error details in parentheses:
```
"Reconnecting... 1/5 (stream disconnected before completion: Transport error: network error: error decoding response body)"
```

## Solution

Remove the `$` anchor to allow matching the prefix:
```python
r'^Reconnecting\.\.\.\s+\d+/\d+'
```

Fixes #22