### PR TITLE
feat: add reasoning_effort parameter to control thinking budget

### DIFF
--- a/src/codexmcp/server.py
+++ b/src/codexmcp/server.py
@@ -180,6 +180,16 @@ async def codex(
             description="The model to use for the codex session. This parameter is strictly prohibited unless explicitly specified by the user.",
         ),
     ] = "",
+    reasoning_effort: Annotated[
+        Optional[Literal["low", "medium", "high", "xhigh"]],
+        Field(
+            description=(
+                "Override Codex config `model_reasoning_effort` (thinking budget). "
+                "Allowed values: low, medium, high, xhigh. "
+                "If omitted, uses the config/profile default."
+            ),
+        ),
+    ] = None,
     yolo: Annotated[
         bool,
         Field(
@@ -203,7 +213,10 @@ async def codex(
         
     if profile:
         cmd.extend(["--profile", profile])
-        
+
+    if reasoning_effort is not None:
+        cmd.extend(["--config", f'model_reasoning_effort="{reasoning_effort}"'])
+
     if yolo:
         cmd.append("--yolo")
     


### PR DESCRIPTION
## Summary
- Add `reasoning_effort` parameter to the codex MCP tool
- Allows dynamic control over model reasoning depth for different task complexities
- Maps to Codex CLI: `--config model_reasoning_effort="<value>"`
- Supported values: `low`, `medium`, `high`, `xhigh`
- Defaults to `None` (uses config/profile default)

## Changes
- Added `reasoning_effort` parameter with `Literal` type validation in `src/codexmcp/server.py`
- Added command-line argument handling to pass the value to Codex CLI

## Test plan
- [x] Verify parameter is correctly passed to Codex CLI
- [x] Test with different reasoning_effort values (low, medium, high, xhigh)
- [x] Verify default behavior (None) doesn't add the --config flag
- [x] Verify invalid values are rejected by type validation

Closes #37