### PR TITLE
feat: support custom codex binary via environment variables

### DIFF
--- a/src/codexmcp/server.py
+++ b/src/codexmcp/server.py
@@ -16,6 +16,8 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import BeforeValidator, Field
 import shutil
 
+CODEX_BINARY = os.environ.get("CODEX_BINARY", "codex")
+
 mcp = FastMCP("Codex MCP Server-from guda.studio")
 
 
@@ -38,7 +40,7 @@ def run_shell_command(cmd: list[str]) -> Generator[str, None, None]:
     # On Windows, codex is exposed via a *.cmd shim. Use cmd.exe with /s so
     # user prompts containing quotes/newlines aren't reinterpreted as shell syntax.
     popen_cmd = cmd.copy()
-    codex_path = shutil.which('codex') or cmd[0]
+    codex_path = shutil.which(CODEX_BINARY) or cmd[0]
     popen_cmd[0] = codex_path
 
     process = subprocess.Popen(
@@ -193,7 +195,7 @@ async def codex(
 ) -> Dict[str, Any]:
     """Execute a Codex CLI session and return the results."""
     # Build command as list to avoid injection
-    cmd = ["codex", "exec", "--sandbox", sandbox, "--cd", str(cd), "--json"]
+    cmd = [CODEX_BINARY, "exec", "--sandbox", sandbox, "--cd", str(cd), "--json"]
     
     if len(image):
         cmd.extend(["--image", ",".join(image)])

--- a/src/codexmcp/server.py
+++ b/src/codexmcp/server.py
@@ -17,6 +17,7 @@ from pydantic import BeforeValidator, Field
 import shutil
 
 CODEX_BINARY = os.environ.get("CODEX_BINARY", "codex")
+CODEX_USE_DOUBLE_DASH = os.environ.get("CODEX_USE_DOUBLE_DASH", "true").lower() == "true"
 
 mcp = FastMCP("Codex MCP Server-from guda.studio")
 
@@ -219,7 +220,10 @@ async def codex(
         PROMPT = windows_escape(PROMPT)
     else:
         PROMPT = PROMPT
-    cmd += ['--', PROMPT]
+    if CODEX_USE_DOUBLE_DASH:
+        cmd += ['--', PROMPT]
+    else:
+        cmd.append(PROMPT)
 
     all_messages: list[Dict[str, Any]] = []
     agent_messages = ""


### PR DESCRIPTION
## Summary

- Add `CODEX_BINARY` env var to allow overriding the codex binary name (defaults to `"codex"` for backward compatibility)
- Add `CODEX_USE_DOUBLE_DASH` env var to control whether `--` separator is used before the prompt in `exec` subcommand (defaults to `"true"`)

This enables CodexMCP to work with internal/custom codex builds (e.g., `codex-internal`) where:
1. The binary has a different name
2. The `exec` subcommand does not support the `--` argument separator

## Usage

```bash
claude mcp add codex -s user --transport stdio \
  -e CODEX_BINARY=codex-internal \
  -e CODEX_USE_DOUBLE_DASH=false \
  -- uvx --from git+https://github.com/GuDaStudio/codexmcp.git codexmcp
```

No changes needed for existing users — both env vars have sensible defaults that preserve current behavior.

## Test plan

- [x] Verified with `codex-internal` (v0.0.6) — tool responds correctly via `claude-internal`
- [x] Default behavior unchanged — `CODEX_BINARY` defaults to `"codex"`, `CODEX_USE_DOUBLE_DASH` defaults to `"true"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)